### PR TITLE
Sort vendor cards alphabetically

### DIFF
--- a/index.html
+++ b/index.html
@@ -1584,7 +1584,9 @@
                 categories.forEach(category => {
                     const section = document.querySelector(`.category-section[data-category="${category}"]`);
                     const container = document.getElementById(`tools-${category}`);
-                    const categoryTools = this.filteredTools.filter(tool => tool.category === category);
+                    const categoryTools = this.filteredTools
+                        .filter(tool => tool.category === category)
+                        .sort((a, b) => a.name.localeCompare(b.name));
 
                     // Clear the container first
                     if (container) {


### PR DESCRIPTION
## Summary
- sort vendors alphabetically when rendering each category

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b52e6305c8331a853368bfabcadcf