### PR TITLE
Fix category tags toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1389,6 +1389,11 @@
 
                 document.querySelectorAll('.category-header').forEach(header => {
                     header.addEventListener('click', (e) => {
+                        if (e.target.closest('.show-more-category-tags-btn') ||
+                            e.target.closest('.show-less-category-tags-btn')) {
+                            return;
+                        }
+
                         const category = header.dataset.category;
                         if (category && this.CATEGORY_INFO[category]) {
                             this.showCategoryModal(this.CATEGORY_INFO[category], category);


### PR DESCRIPTION
## Summary
- don't open category modal when clicking show/hide tag buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b59af0bb88331a3c2587592955649