### PR TITLE
Fix modal overlay position

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,7 +576,7 @@
 
         /* IFRAME-OPTIMIZED MODAL STYLES */
         .modal {
-            position: absolute !important;
+            position: fixed !important;
             top: 0 !important;
             left: 0 !important;
             width: 100% !important;


### PR DESCRIPTION
## Summary
- use `position: fixed` for modals so they stay within the viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b5afa65508331bad1799ffdc49ba2