### PR TITLE
Ensure page scrolls to top on refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -1830,6 +1830,15 @@
             setTimeout(sendHeight, 300);
         });
     </script>
+    <script>
+        if ('scrollRestoration' in history) {
+            history.scrollRestoration = 'manual';
+        }
+
+        window.addEventListener('load', () => {
+            window.scrollTo(0, 0);
+        });
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- reset scroll position on page load by setting `history.scrollRestoration` to `'manual'`
- scroll to the top when the page is loaded

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b5bc446d48331ae8dd278d6ab2249