### PR TITLE
Add Vesto video link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1219,6 +1219,7 @@
                         "desc": "Cash investment platform with yield optimization, risk monitoring, and liquidity management for maximizing returns on excess cash positions.",
                         "features": ["Yield optimization", "Risk monitoring", "Investment tracking", "Liquidity management", "Performance analytics", "Compliance tools"],
                         "target": "Companies with significant cash positions seeking yield optimization",
+                        "videoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Vesto-06-2025.mp4",
                         "websiteUrl": "https://www.vesto.com/about?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
                     },
 


### PR DESCRIPTION
## Summary
- add missing video URL for the Vesto tool card in the HTML data list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b7577bce0833193a14b727ac39926