### PR TITLE
Improve side menu design

### DIFF
--- a/index.html
+++ b/index.html
@@ -917,15 +917,20 @@
         .side-menu {
             position: fixed;
             top: 0;
-            left: -400px;
-            width: 400px;
+            left: -380px;
+            width: 380px;
             height: 100vh;
-            background: white;
-            box-shadow: 10px 0 30px rgba(0, 0, 0, 0.1);
+            background: linear-gradient(135deg,
+                rgba(255, 255, 255, 0.95) 0%,
+                rgba(248, 248, 248, 0.98) 100%);
+            backdrop-filter: blur(20px) saturate(130%);
+            -webkit-backdrop-filter: blur(20px) saturate(130%);
+            box-shadow: 10px 0 30px rgba(114, 22, 244, 0.15);
+            border-right: 1px solid rgba(199, 125, 255, 0.2);
+            border-radius: 0 16px 16px 0;
             z-index: 1001;
-            transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            transition: left 0.35s cubic-bezier(0.4, 0, 0.2, 1);
             overflow-y: auto;
-            border-right: 1px solid #e5e7eb;
         }
 
         .side-menu.open {
@@ -941,7 +946,7 @@
         }
 
         body.side-menu-pinned .container {
-            margin-left: 400px;
+            margin-left: 380px;
         }
 
         body.side-menu-pinned #menuToggle {
@@ -954,8 +959,9 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: rgba(40, 19, 69, 0.4);
-            backdrop-filter: blur(4px);
+            background: rgba(40, 19, 69, 0.45);
+            backdrop-filter: blur(6px) saturate(120%);
+            -webkit-backdrop-filter: blur(6px) saturate(120%);
             z-index: 1000;
             opacity: 0;
             visibility: hidden;


### PR DESCRIPTION
## Summary
- use a frosted glass background for the side menu and overlay
- adjust pinned layout margin

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c2634f4088331b0c388723b329bcf