### PR TITLE
Fix drag-and-drop issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -2328,6 +2328,7 @@
 
                 card.addEventListener('dragstart', (e) => {
                     e.dataTransfer.setData('text/plain', tool.name);
+                    this.openShortlistMenu(true);
                 });
 
                 return card;


### PR DESCRIPTION
## Summary
- ensure shortlist menu opens in pinned mode when a card drag starts so overlay doesn't block interaction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c390a664c8331b030ca299d580c05