### PR TITLE
Fix shortlist drag drop area

### DIFF
--- a/index.html
+++ b/index.html
@@ -1283,6 +1283,9 @@
             flex-direction:column;
             gap:8px;
             margin-top:12px;
+            min-height:80px;
+            border:1px dashed #e5e7eb;
+            padding:8px;
         }
 
         .shortlist-card {


### PR DESCRIPTION
## Summary
- make shortlist container visible by adding a minimum height

## Testing
- `git show -n 1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c3cbc5a848331a1b48294659d8852