### PR TITLE
Fix merge conflict remnants in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1229,7 +1229,6 @@
         body.side-menu-pinned .external-menu-toggle {
             display: none;
         }
-<<<<<<< codex/add-shortlist-drag-and-drop-menu
 
         /* Shortlist Menu */
         .shortlist-menu {
@@ -1373,47 +1372,6 @@
             border-radius: 8px;
         }
 
-        .external-menu-toggle {
-            position: fixed;
-            top: 20px;
-            left: 20px;
-            background: #7216f4;
-            border: none;
-            width: 36px;
-            height: 36px;
-            border-radius: 50%;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: #fff;
-            transition: all 0.3s ease;
-            box-shadow: 0 1px 4px rgba(0,0,0,0.1);
-            z-index: 1002;
-        }
-
-        .external-menu-toggle:hover {
-            background: #5b0ee3;
-        }
-
-        .external-menu-toggle .chevron {
-            width: 12px;
-            height: 12px;
-            border-right: 2px solid currentColor;
-            border-bottom: 2px solid currentColor;
-            transform: rotate(45deg);
-            transition: transform 0.25s ease;
-        }
-
-        .external-menu-toggle.active .chevron {
-            transform: rotate(-135deg);
-        }
-
-        body.side-menu-pinned .external-menu-toggle {
-            display: none;
-        }
-=======
->>>>>>> main
     </style>
 </head>
 


### PR DESCRIPTION
## Summary
- remove conflict markers from `index.html`
- keep only one copy of `.external-menu-toggle` styles

## Testing
- `grep -n '<<<<<<<\|======\|>>>>>>>' -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c4541f5308331835f65aa8038e465