### PR TITLE
Fix side menu overlap and empty shortlist

### DIFF
--- a/index.html
+++ b/index.html
@@ -1021,9 +1021,9 @@
             overflow: visible;
         }
 
-        /* Ensure toggle remains clickable when menu is closed */
+        /* Hide internal toggle when the menu is closed to avoid overlap */
         .side-menu:not(.open) .menu-toggle {
-            pointer-events: auto;
+            display: none;
         }
 
         .side-menu-pin {
@@ -1344,6 +1344,19 @@
             min-height:80px;
             border:1px dashed #e5e7eb;
             padding:8px;
+        }
+
+        /* Show instructions when the shortlist is empty */
+        .shortlist-container:empty {
+            justify-content:center;
+            align-items:center;
+        }
+
+        .shortlist-container:empty::before {
+            content: 'Drag and drop vendor cards here';
+            color: #4b5563;
+            font-size: 0.85rem;
+            text-align: center;
         }
 
         .shortlist-card {


### PR DESCRIPTION
## Summary
- hide internal toggle when the menu is collapsed so only one button shows
- display a helper message inside the shortlist box when no vendors are present

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c49a7431883319408c94ac03ef78d