### PR TITLE
Update Lite tool icon gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,7 +556,7 @@
         }
 
         .tool-lite .tool-icon {
-            background: linear-gradient(135deg, rgba(143, 71, 246, 0.8), rgba(199, 125, 255, 0.8));
+            background: linear-gradient(135deg, rgba(255,122,0,0.8), rgba(255,173,20,0.8));
             backdrop-filter: blur(4px);
             -webkit-backdrop-filter: blur(4px);
         }


### PR DESCRIPTION
## Summary
- tweak the `.tool-lite .tool-icon` gradient in `index.html` to use an orange gradient

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c61fa2e10833191cb369f2297aa32