### PR TITLE
Remove blur filters from side overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,8 +946,6 @@
             width: 340px;
             height: 100vh;
             background: rgba(255, 255, 255, 0.05);
-            backdrop-filter: blur(4px) saturate(120%);
-            -webkit-backdrop-filter: blur(4px) saturate(120%);
             box-shadow: 0 8px 32px rgba(31, 38, 135, 0.37);
             border-right: 1px solid rgba(255, 255, 255, 0.1);
             border-radius: 0 20px 20px 0;
@@ -991,7 +989,6 @@
             width: 100%;
             height: 100%;
             background: rgba(40, 19, 69, 0.1);
-            backdrop-filter: blur(2px);
             z-index: 1000;
             opacity: 0;
             visibility: hidden;
@@ -1277,8 +1274,6 @@
             width: 340px;
             height: 100vh;
             background: rgba(255,255,255,0.05);
-            backdrop-filter: blur(4px) saturate(120%);
-            -webkit-backdrop-filter: blur(4px) saturate(120%);
             box-shadow: 0 8px 32px rgba(31,38,135,0.37);
             border-left: 1px solid rgba(255,255,255,0.1);
             border-radius: 20px 0 0 20px;
@@ -1308,7 +1303,6 @@
             width:100%;
             height:100%;
             background: rgba(40,19,69,0.1);
-            backdrop-filter: blur(2px);
             z-index:1000;
             opacity:0;
             visibility:hidden;


### PR DESCRIPTION
## Summary
- remove backdrop filters from side menu and shortlist menu to disable blur
- clean overlay backdrop rules

## Testing
- `grep -n "backdrop-filter" -n index.html | head -n 15`

------
https://chatgpt.com/codex/tasks/task_e_685c6261e6d08331852cd8f0457cd7eb