### PR TITLE
Remove UTM query params in shortlist export

### DIFF
--- a/index.html
+++ b/index.html
@@ -2913,7 +2913,7 @@
                 const data = this.shortlist.map(item => ({
                     name: item.tool.name,
                     category: item.tool.category,
-                    website: item.tool.websiteUrl || '',
+                    website: item.tool.websiteUrl ? item.tool.websiteUrl.split('?')[0] : '',
                     notes: item.notes || ''
                 }));
                 const csv = this.convertToCSV(data);


### PR DESCRIPTION
## Summary
- strip query strings from `website` links when exporting a shortlist

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c642664c88331a028596e248cbd7c