### PR TITLE
Adjust TMS-Lite icon color

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,7 +565,7 @@
         }
 
         .tool-lite .tool-icon {
-            background: linear-gradient(135deg, rgba(255,122,0,0.8), rgba(255,173,20,0.8));
+            background: linear-gradient(135deg, rgba(59,130,246,0.8), rgba(29,78,216,0.8));
             backdrop-filter: blur(4px);
             -webkit-backdrop-filter: blur(4px);
         }


### PR DESCRIPTION
## Summary
- update the `tool-lite` icon gradient to use a brand-friendly blue tone

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c649ea1d483319e878ff0d500edec