### PR TITLE
Remove CSS min-height constraints

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             background: #f8f9fa;
             color: #281345;
-            min-height: 100vh;
             line-height: 1.6;
             font-weight: 400;
             -webkit-font-smoothing: antialiased;
@@ -38,7 +37,6 @@
         }
 
         .container {
-            min-height: 100vh;
             position: relative;
             margin-left: 60px;
             margin-right: 60px;


### PR DESCRIPTION
## Summary
- adjust `index.html` to remove fixed `min-height` usage from `body` and `.container`

## Testing
- `grep -n min-height index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c67483f788331b13071d5aaa2dcc0