### PR TITLE
Remove 'Ideal For' from category summary modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1730,10 +1730,6 @@
                             <!-- Features will be populated by JavaScript -->
                         </ul>
                     </div>
-                    <div class="feature-section">
-                        <h4>🏢 Ideal For</h4>
-                        <p id="categoryModalTarget"></p>
-                    </div>
                 </div>
             </div>
         </div>
@@ -1987,7 +1983,6 @@
                             "Cash Visibility",
                             "Transaction Search, Sort, Tag, Group"
                         ],
-                        target: "Growing businesses, mid-market companies, and finance teams seeking to automate manual cash management processes and gain real-time visibility.",
                         videoUrl: ""
                     },
                     LITE: {
@@ -2003,7 +1998,6 @@
                             "Market Data",
                             "Treasury Payments (API, SFTP)"
                         ],
-                        "target": "Growing companies, mid-market enterprises, and organizations that have outgrown basic cash tools but don't need full TRMS complexity.",
                         videoUrl: ""
                     },
                     TRMS: {
@@ -2033,7 +2027,6 @@
                             "Investments",
                             "SWIFT Connectivity"
                         ],
-                        target: "Large enterprises, multinational corporations, and financial institutions with complex treasury operations requiring full-scale treasury management capabilities.",
                         videoUrl: ""
                     }
                 };
@@ -2289,13 +2282,11 @@
                 const modal = document.getElementById('categoryModal');
                 const modalTitle = document.getElementById('categoryModalTitle');
                 const modalDescription = document.getElementById('categoryModalDescription');
-                const modalTarget = document.getElementById('categoryModalTarget');
                 const modalFeatures = document.getElementById('categoryModalFeatures');
                 const modalBody = modal?.querySelector('.modal-body');
 
                 if (modalTitle) modalTitle.textContent = categoryInfo.name;
                 if (modalDescription) modalDescription.textContent = categoryInfo.description;
-                if (modalTarget) modalTarget.textContent = categoryInfo.target;
 
                 if (modalFeatures) {
                     modalFeatures.innerHTML = '';


### PR DESCRIPTION
## Summary
- remove the "Ideal For" HTML section from category modals
- drop modalTarget handling in the script
- clean unused `target` fields from `CATEGORY_INFO`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c700313b483318d0e82a9ff862cf6