### PR TITLE
Add grouping toggle for vendor list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1568,6 +1568,13 @@
                                 <option value="4">4</option>
                             </select>
                         </div>
+                        <div class="filter-group">
+                            <label class="filter-label" for="groupByFilter">Group Vendors</label>
+                            <select id="groupByFilter" class="filter-select">
+                                <option value="category" selected>By Category</option>
+                                <option value="none">No Grouping</option>
+                            </select>
+                        </div>
                     </div>
                 </div>
 
@@ -2050,6 +2057,7 @@
                 this.currentSort = 'name';
                 this.currentView = 'grid';
                 this.gridSize = 'auto';
+                this.groupByCategory = true;
                 this.sideMenuOpen = false;
                 this.sideMenuPinned = false;
                 this.shortlist = [];
@@ -2397,7 +2405,7 @@
                 if (noResults) noResults.style.display = hasResults ? 'none' : 'block';
 
                 const listContainer = document.getElementById('listViewContainer');
-                const ungroup = this.currentView === 'list' || this.searchTerm ||
+                const ungroup = !this.groupByCategory || this.currentView === 'list' || this.searchTerm ||
                                 this.advancedFilters.features.length || this.advancedFilters.hasVideo;
 
                 if (ungroup) {
@@ -2661,6 +2669,14 @@
                     gridSizeFilter.addEventListener('change', (e) => {
                         this.gridSize = e.target.value;
                         this.applyGridSize();
+                    });
+                }
+
+                const groupByFilter = document.getElementById('groupByFilter');
+                if (groupByFilter) {
+                    groupByFilter.addEventListener('change', (e) => {
+                        this.groupByCategory = e.target.value === 'category';
+                        this.filterAndDisplayTools();
                     });
                 }
             }
@@ -3000,6 +3016,10 @@
                 const gridSizeFilter = document.getElementById('gridSizeFilter');
                 if (gridSizeFilter) gridSizeFilter.value = 'auto';
                 this.gridSize = 'auto';
+
+                const groupByFilter = document.getElementById('groupByFilter');
+                if (groupByFilter) groupByFilter.value = 'category';
+                this.groupByCategory = true;
 
                 this.applyViewStyles();
                 this.filterAndDisplayTools();


### PR DESCRIPTION
## Summary
- add `Group Vendors` dropdown to view options
- store new `groupByCategory` preference
- adjust display logic to allow ungrouped results
- handle dropdown changes and reset default

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c722ccad8833180d93753abc398b4