### PR TITLE
Shrink left menu spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1012,7 +1012,7 @@
         }
 
         .side-menu-header {
-            padding: 20px;
+            padding: 12px 16px;
             border-bottom: 1px solid #e5e7eb;
             display: flex;
             align-items: center;
@@ -1075,7 +1075,7 @@
         }
 
         .menu-section-header {
-            padding: 16px 20px;
+            padding: 8px 16px;
             background: rgba(249, 250, 251, 0.8);
             font-weight: 600;
             color: #281345;
@@ -1086,11 +1086,11 @@
         }
 
         .menu-section-content {
-            padding: 20px;
+            padding: 12px 16px;
         }
 
         .filter-group {
-            margin-bottom: 24px;
+            margin-bottom: 12px;
         }
 
         .filter-group:last-child {
@@ -1102,7 +1102,7 @@
             font-size: 0.9rem;
             font-weight: 600;
             color: #374151;
-            margin-bottom: 8px;
+            margin-bottom: 4px;
         }
 
         .filter-select,
@@ -1153,18 +1153,18 @@
         .view-options {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            gap: 8px;
+            gap: 6px;
         }
 
         .view-option {
             background: #f9fafb;
             border: 1px solid #e5e7eb;
             border-radius: 8px;
-            padding: 12px;
+            padding: 8px;
             text-align: center;
             cursor: pointer;
             transition: all 0.3s ease;
-            font-size: 0.8rem;
+            font-size: 0.75rem;
         }
 
         .view-option.active {
@@ -1181,13 +1181,13 @@
         .action-buttons {
             display: flex;
             flex-direction: column;
-            gap: 12px;
+            gap: 8px;
         }
 
         .action-btn {
-            padding: 10px 16px;
+            padding: 8px 12px;
             border-radius: 8px;
-            font-size: 0.85rem;
+            font-size: 0.8rem;
             font-weight: 500;
             cursor: pointer;
             transition: all 0.3s ease;


### PR DESCRIPTION
## Summary
- reduce padding in the left-side menu header and sections
- tighten margins and font sizes for filters and buttons

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c786047888331b45437e2a640cfcd