### PR TITLE
Add right menu toggle and shortlist tips

### DIFF
--- a/index.html
+++ b/index.html
@@ -1276,6 +1276,60 @@
             display: none;
         }
 
+        .external-shortlist-toggle {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: rgba(255,255,255,0.15);
+            border: 1px solid rgba(255,255,255,0.3);
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #7216f4;
+            transition: background 0.3s ease;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+            z-index: 1002;
+        }
+
+        .external-shortlist-toggle:hover {
+            background: rgba(255,255,255,0.25);
+        }
+
+        .external-shortlist-toggle .icon {
+            width: 100%;
+            height: 100%;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.7);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: background 0.3s ease, color 0.3s ease;
+        }
+
+        .external-shortlist-toggle .icon::before {
+            content: '\2630';
+        }
+
+        .external-shortlist-toggle.active .icon {
+            background: rgba(114,22,244,0.9);
+            color: #fff;
+        }
+
+        .external-shortlist-toggle.active .icon::before {
+            content: '\2715';
+        }
+
+        body.shortlist-menu-open .external-shortlist-toggle,
+        body.shortlist-menu-pinned .external-shortlist-toggle {
+            display: none;
+        }
+
         /* Shortlist Menu */
         .shortlist-menu {
             position: fixed;
@@ -1465,6 +1519,35 @@
             align-items:center;
         }
 
+        .tips-section {
+            background: #fff;
+            border: 1px solid #e5e7eb;
+            border-radius: 16px;
+            padding: 20px;
+            margin: 40px auto;
+            max-width: 800px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        }
+
+        .tips-section h3 {
+            margin-bottom: 12px;
+            font-size: 1.4rem;
+            font-weight: 700;
+            color: #281345;
+        }
+
+        .tips-section ul {
+            padding-left: 20px;
+            list-style: disc;
+        }
+
+        .tips-section li {
+            margin-bottom: 8px;
+            color: #7e7e7e;
+            font-size: 0.95rem;
+        }
+
 
 
 
@@ -1474,6 +1557,9 @@
 <body>
     <div class="container">
         <button class="external-menu-toggle" id="externalMenuToggle">
+            <span class="icon"></span>
+        </button>
+        <button class="external-shortlist-toggle" id="externalShortlistToggle" aria-label="Open shortlist menu" title="Shortlist">
             <span class="icon"></span>
         </button>
         <!-- Loading Screen -->
@@ -1737,6 +1823,15 @@
                     </div>
                 </div>
             </div>
+        </div>
+        <div class="tips-section">
+            <h3>Tips for Building a Tech Vendor Shortlist</h3>
+            <ul>
+                <li>Define must-have features and your budget early on.</li>
+                <li>Check how well each tool integrates with current systems.</li>
+                <li>Ask for references or case studies from similar companies.</li>
+                <li>Consider future scalability and support options.</li>
+            </ul>
         </div>
     </div>
 
@@ -2742,11 +2837,13 @@
                 const menuToggle = document.getElementById('shortlistMenuToggle');
                 const overlay = document.getElementById('shortlistMenuOverlay');
                 const pinBtn = document.getElementById('shortlistMenuPin');
+                const externalToggle = document.getElementById('externalShortlistToggle');
                 const container = document.getElementById('shortlistContainer');
                 const clearBtn = document.getElementById('clearShortlist');
                 const exportBtn = document.getElementById('exportShortlistBtn');
 
                 if (menuToggle) menuToggle.addEventListener('click', () => this.toggleShortlistMenu());
+                if (externalToggle) externalToggle.addEventListener('click', () => this.toggleShortlistMenu());
                 if (overlay) overlay.addEventListener('click', () => this.closeShortlistMenu());
                 if (pinBtn) pinBtn.addEventListener('click', () => this.togglePinShortlistMenu());
                 if (clearBtn) clearBtn.addEventListener('click', () => this.clearShortlist());
@@ -2819,17 +2916,20 @@
                 const menu = document.getElementById('shortlistMenu');
                 const overlay = document.getElementById('shortlistMenuOverlay');
                 const toggle = document.getElementById('shortlistMenuToggle');
+                const externalToggle = document.getElementById('externalShortlistToggle');
 
                 menu?.classList.add('open');
                 document.body.classList.add('shortlist-menu-open');
                 if (pinned) {
                     overlay?.classList.remove('show');
                     toggle?.classList.remove('active');
+                    externalToggle?.classList.remove('active');
                     document.body.classList.add('shortlist-menu-pinned');
                     document.body.style.overflow = '';
                 } else {
                     overlay?.classList.add('show');
                     toggle?.classList.add('active');
+                    externalToggle?.classList.add('active');
                     document.body.classList.remove('shortlist-menu-pinned');
                     document.body.style.overflow = 'hidden';
                 }
@@ -2840,12 +2940,14 @@
                 const menu = document.getElementById('shortlistMenu');
                 const overlay = document.getElementById('shortlistMenuOverlay');
                 const toggle = document.getElementById('shortlistMenuToggle');
+                const externalToggle = document.getElementById('externalShortlistToggle');
                 const pinBtn = document.getElementById('shortlistMenuPin');
 
                 menu?.classList.remove('open');
                 document.body.classList.remove('shortlist-menu-open');
                 overlay?.classList.remove('show');
                 toggle?.classList.remove('active');
+                externalToggle?.classList.remove('active');
                 document.body.classList.remove('shortlist-menu-pinned');
                 document.body.style.overflow = '';
                 this.shortlistMenuOpen = false;


### PR DESCRIPTION
## Summary
- add external toggle button for shortlist menu
- hide shortlist toggle when the menu is open or pinned
- include a tips section on building a tech vendor shortlist

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c7c79d3448331aa66b4b79cbf8acf