### PR TITLE
Fix shortlist overlay dragging

### DIFF
--- a/index.html
+++ b/index.html
@@ -2997,7 +2997,7 @@
                 if (shortlistMenu) shortlistMenu.addEventListener('click', (e) => {
                     if (!this.shortlistMenuOpen && e.target === shortlistMenu) {
                         e.stopPropagation();
-                        this.openShortlistMenu();
+                        this.openShortlistMenu(true);
                     }
                 });
                 if (clearBtn) clearBtn.addEventListener('click', () => this.clearShortlist());
@@ -3093,7 +3093,7 @@
 
             toggleShortlistMenu() {
                 if (this.shortlistMenuOpen) this.closeShortlistMenu();
-                else this.openShortlistMenu();
+                else this.openShortlistMenu(true);
             }
 
             openShortlistMenu(pinned = false) {


### PR DESCRIPTION
## Summary
- update shortlist event to open pinned when clicking collapsed menu
- open pinned when toggling shortlist menu

This lets users drag vendor tool cards even when the right menu is opened first.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c8891ca488331a1c4512cdb7e96c2