### PR TITLE
Specify postMessage origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Treasury Tech Stack
+
+This page is designed to be embedded within another site via an iframe. In order for height updates to work securely, it posts messages to the parent window.
+
+The parent window origin expected to embed this page is defined in `index.html` by the `EMBED_ORIGIN` constant. Currently this value is set to `https://realtreasury.com`. If you embed the page on a different domain, update the constant to match the parent origin so that the `postMessage` calls succeed.
+
+```javascript
+const EMBED_ORIGIN = 'https://realtreasury.com';
+```
+
+Any deployment embedding this page **must** come from the configured origin, or adjust the constant accordingly.

--- a/index.html
+++ b/index.html
@@ -1911,12 +1911,13 @@
 
 
     <script>
+        const EMBED_ORIGIN = 'https://realtreasury.com';
         let treasuryStack;
 
         function postHeight() {
             if (window.parent !== window) {
                 const h = document.documentElement.scrollHeight;
-                window.parent.postMessage({ type: 'treasury-height', height: h }, '*');
+                window.parent.postMessage({ type: 'treasury-height', height: h }, EMBED_ORIGIN);
             }
         }
 
@@ -2542,7 +2543,7 @@
                     // Stop video from playing in the background
                     const iframe = modal.querySelector('iframe');
                     if (iframe && iframe.contentWindow) {
-                        iframe.contentWindow.postMessage('{"event":"command","func":"pauseVideo","args":""}', '*');
+                        iframe.contentWindow.postMessage('{"event":"command","func":"pauseVideo","args":""}', 'https://www.youtube.com');
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- specify parent `postMessage` origin using constant `EMBED_ORIGIN`
- limit YouTube postMessage to youtube.com
- document origin in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c899153708331850a20783d0ff1ff