### PR TITLE
Fix mobile side menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -918,6 +918,10 @@
             body.side-menu-pinned .container {
                 margin-left: 0;
             }
+            .side-menu-pin,
+            .shortlist-menu-pin {
+                display: none;
+            }
         }
 
         /* Side Menu Toggle Button */
@@ -2997,7 +3001,7 @@
                 if (shortlistMenu) shortlistMenu.addEventListener('click', (e) => {
                     if (!this.shortlistMenuOpen && e.target === shortlistMenu) {
                         e.stopPropagation();
-                        this.openShortlistMenu(true);
+                        this.openShortlistMenu();
                     }
                 });
                 if (clearBtn) clearBtn.addEventListener('click', () => this.clearShortlist());
@@ -3093,7 +3097,7 @@
 
             toggleShortlistMenu() {
                 if (this.shortlistMenuOpen) this.closeShortlistMenu();
-                else this.openShortlistMenu(true);
+                else this.openShortlistMenu();
             }
 
             openShortlistMenu(pinned = false) {


### PR DESCRIPTION
## Summary
- hide side menu pin buttons on small screens
- open shortlist menu unpinned by default

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_685c8a2a97bc8331aa309554e7d0daaa