### PR TITLE
Improve tag filtering UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -1683,6 +1683,11 @@
                         </div>
                         <div class="filter-group">
                             <span class="filter-label">Tags</span>
+                            <div class="search-container">
+                                <span class="search-icon">🔍</span>
+                                <input type="text" id="tagSearchInput" class="search-input" placeholder="Search tags...">
+                                <button class="search-clear" id="tagSearchClear" style="display: none;">×</button>
+                            </div>
                             <div class="checkbox-group" id="tagFilters"></div>
                         </div>
                         <div class="filter-group">
@@ -2233,6 +2238,7 @@
                 this.currentFilter = 'ALL';
                 this.searchTerm = '';
                 this.filteredTools = [];
+                this.allTags = [];
                 this.advancedFilters = { features: [], hasVideo: false };
                 this.currentSort = 'name';
                 this.currentView = 'grid';
@@ -2368,6 +2374,55 @@
                         searchClear.style.display = 'none';
                         this.filterAndDisplayTools();
                     });
+                }
+            }
+
+            setupTagSearch() {
+                const searchInput = document.getElementById('tagSearchInput');
+                const searchClear = document.getElementById('tagSearchClear');
+
+                if (searchInput) {
+                    searchInput.addEventListener('input', () => {
+                        const term = searchInput.value.toLowerCase();
+                        if (searchClear) searchClear.style.display = term ? 'block' : 'none';
+                        this.filterTagCheckboxes(term);
+                    });
+                }
+
+                if (searchClear) {
+                    searchClear.addEventListener('click', () => {
+                        if (searchInput) {
+                            searchInput.value = '';
+                            searchInput.focus();
+                        }
+                        searchClear.style.display = 'none';
+                        this.filterTagCheckboxes('');
+                    });
+                }
+            }
+
+            filterTagCheckboxes(term) {
+                const container = document.getElementById('tagFilters');
+                if (!container) return;
+                const items = container.querySelectorAll('.checkbox-item');
+                items.forEach(item => {
+                    const label = item.textContent.toLowerCase();
+                    item.style.display = label.includes(term) ? 'flex' : 'none';
+                });
+
+                const showMore = document.getElementById('showMoreTagFilters');
+                const showLess = document.getElementById('showLessTagFilters');
+                const extra = document.getElementById('extraTagFilters');
+                if (showMore && showLess && extra) {
+                    if (term) {
+                        extra.style.display = 'block';
+                        showMore.style.display = 'none';
+                        showLess.style.display = 'none';
+                    } else {
+                        extra.style.display = 'none';
+                        showLess.style.display = 'none';
+                        showMore.style.display = 'inline-block';
+                    }
                 }
             }
 
@@ -2765,7 +2820,8 @@
                 const container = document.getElementById('tagFilters');
                 if (!container) return;
                 const tags = [...new Set(Object.values(this.CATEGORY_TAGS).flat())].sort((a, b) => a.localeCompare(b));
-                const displayCount = 6;
+                this.allTags = tags;
+                const displayCount = 4;
                 const visible = tags.slice(0, displayCount);
                 const hidden = tags.slice(displayCount);
                 const makeCb = (tag) => {
@@ -2843,6 +2899,7 @@
 
             setupAdvancedFilters() {
                 this.populateTagFilters();
+                this.setupTagSearch();
                 const showMore = document.getElementById('showMoreTagFilters');
                 const showLess = document.getElementById('showLessTagFilters');
                 const extra = document.getElementById('extraTagFilters');
@@ -3320,6 +3377,13 @@
                     searchInput.value = '';
                     this.searchTerm = '';
                 }
+                const tagSearchInput = document.getElementById('tagSearchInput');
+                if (tagSearchInput) {
+                    tagSearchInput.value = '';
+                }
+                const tagSearchClear = document.getElementById('tagSearchClear');
+                if (tagSearchClear) tagSearchClear.style.display = 'none';
+                this.filterTagCheckboxes('');
                 document.querySelector('.filter-tab.active')?.classList.remove('active');
                 document.querySelector('.filter-tab[data-category="ALL"]')?.classList.add('active');
                 this.currentFilter = 'ALL';


### PR DESCRIPTION
## Summary
- allow searching tag filters
- trim visible tags before `Show more`

## Testing
- `node -e "const fs=require('fs');const txt=fs.readFileSync('index.html','utf8');const scripts=[...txt.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m=>m[1]);scripts.forEach((s,i)=>{try{new Function(s); console.log('Script',i,'parsed');}catch(e){console.error('Script',i,'error',e.message);}});"`


------
https://chatgpt.com/codex/tasks/task_e_685c8ad746908331a14db8e3b505c371