### PR TITLE
Move tips section into shortlist menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -1698,6 +1698,15 @@
                     <div id="shortlistContainer" class="shortlist-container empty">
                         <p id="shortlistEmptyMessage" class="shortlist-empty-message">Drag vendor cards here to build your shortlist.</p>
                     </div>
+                    <div class="tips-section">
+                        <h3>Tips for Building a Tech Vendor Shortlist</h3>
+                        <ul>
+                            <li>Define must-have features and your budget early on.</li>
+                            <li>Check how well each tool integrates with current systems.</li>
+                            <li>Ask for references or case studies from similar companies.</li>
+                            <li>Consider future scalability and support options.</li>
+                        </ul>
+                    </div>
                     <button class="action-btn secondary" id="clearShortlist" style="margin-top:12px;">Clear Shortlist</button>
                     <button class="action-btn primary" id="exportShortlistBtn" style="margin-top:12px;" disabled>Export Shortlist</button>
                 </div>
@@ -1828,15 +1837,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="tips-section">
-            <h3>Tips for Building a Tech Vendor Shortlist</h3>
-            <ul>
-                <li>Define must-have features and your budget early on.</li>
-                <li>Check how well each tool integrates with current systems.</li>
-                <li>Ask for references or case studies from similar companies.</li>
-                <li>Consider future scalability and support options.</li>
-            </ul>
         </div>
 
         <!-- Project Summary Modal -->


### PR DESCRIPTION
## Summary
- move the vendor shortlist tips panel under the shortlist drop zone

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c8dbfc0108331a6374aa4d937ceb7