### PR TITLE
Fix drag-and-drop when shortlist opened by click

### DIFF
--- a/index.html
+++ b/index.html
@@ -1367,7 +1367,8 @@
         .shortlist-menu-overlay.show {
             opacity:1;
             visibility:visible;
-            pointer-events:auto;
+            /* Allow dragging tools while the shortlist is open */
+            pointer-events:none;
         }
 
         .shortlist-menu-header {


### PR DESCRIPTION
## Summary
- allow tool card drag events when the shortlist menu is already open

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c8e223bc48331888f1b1630434f66