### PR TITLE
Center tips section heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -1509,6 +1509,7 @@
             font-size: 1.4rem;
             font-weight: 700;
             color: #281345;
+            text-align: center;
         }
 
         .tips-section ul {


### PR DESCRIPTION
## Summary
- center the tips section heading for a smoother look

## Testing
- `grep -n "Tips for Building" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c8f3d01488331ae664b71029f86a3