### PR TITLE
Fix CSS merge conflict

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,7 +924,6 @@
                 width: 100%;
                 transform: translateX(-100%);
             }
-<<<<<<< codex/fix-mobile-side-menu-layout
             body.side-menu-pinned .container {
                 margin-left: 0;
             }
@@ -932,8 +931,6 @@
             .shortlist-menu-pin {
                 display: none;
             }
-=======
->>>>>>> main
         }
 
         /* Side Menu Toggle Button */


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from `index.html`
- keep the intended mobile side menu pin CSS block

## Testing
- `grep -n '<<<\|>>>\|=======' -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c90539c608331a603d10a8d7be498