### PR TITLE
Fix stray .side-menu declaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -892,8 +892,6 @@
             .modal-body {
                 padding: 16px;
             }
-            .side-menu {
-
             .title-section h1 {
                 font-size: 1.5rem;
             }


### PR DESCRIPTION
## Summary
- remove empty `.side-menu {` from mobile media query

## Testing
- `tidy -q -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c926df884833182e1c4d1eb3f2bec