### PR TITLE
Adjust external toggles sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1220,8 +1220,8 @@
             border: 1px solid rgba(255,255,255,0.3);
             backdrop-filter: blur(10px);
             -webkit-backdrop-filter: blur(10px);
-            width: 36px;
-            height: 36px;
+            width: 44px;
+            height: 44px;
             border-radius: 50%;
             cursor: pointer;
             display: flex;
@@ -1245,6 +1245,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            font-size: 20px;
             transition: background 0.3s ease, color 0.3s ease;
         }
 
@@ -1273,8 +1274,8 @@
             border: 1px solid rgba(255,255,255,0.3);
             backdrop-filter: blur(10px);
             -webkit-backdrop-filter: blur(10px);
-            width: 36px;
-            height: 36px;
+            width: 44px;
+            height: 44px;
             border-radius: 50%;
             cursor: pointer;
             display: flex;
@@ -1298,6 +1299,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            font-size: 20px;
             transition: background 0.3s ease, color 0.3s ease;
         }
 


### PR DESCRIPTION
## Summary
- resize `.external-menu-toggle` and `.external-shortlist-toggle` to `44px` square
- bump icon size to `20px` so the layout matches prior look

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c9c81ba0883318f3c1183e0ae9a15