### PR TITLE
Hide bottom nav by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1580,6 +1580,9 @@
         }
 
         /* Bottom navigation for mobile */
+        .bottom-nav {
+            display: none;
+        }
         @media (max-width: 768px) {
             .bottom-nav {
                 position: fixed;


### PR DESCRIPTION
## Summary
- hide the bottom navigation by default
- keep existing bottom nav styles for mobile

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_685ca5318b388331b976eeaf92d5f364