### PR TITLE
Hide menu toggles on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -832,7 +832,8 @@
         }
 
         /* Mobile adjustments */
-        @media (max-width: 768px) {
+        /* Hide external toggles across common mobile widths */
+        @media (max-width: 1024px) {
             .header-content {
                 flex-direction: column;
                 align-items: stretch;


### PR DESCRIPTION
## Summary
- hide `.external-menu-toggle` and `.external-shortlist-toggle` for screens up to 1024px wide

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ca52fc8fc8331abc9e5c227c89bc2