### PR TITLE
Enable dragging tool cards with side menu open

### DIFF
--- a/index.html
+++ b/index.html
@@ -1042,7 +1042,7 @@
         .side-menu-overlay.show {
             opacity: 1;
             visibility: visible;
-            pointer-events: auto;
+            pointer-events: none;
         }
 
         .side-menu-header {
@@ -2284,6 +2284,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.shortlistMenuOpen = false;
                 this.touchDragTool = null;
                 this.previousFocusedElement = null;
+                this.handleOutsideSideMenuClick = (e) => {
+                    const sideMenu = document.getElementById('sideMenu');
+                    const toggle = document.getElementById('sideMenuToggle');
+                    const externalToggle = document.getElementById('externalMenuToggle');
+                    if (sideMenu && !sideMenu.contains(e.target) &&
+                        !toggle?.contains(e.target) &&
+                        !externalToggle?.contains(e.target)) {
+                        this.closeSideMenu();
+                    }
+                };
 
                 this.init();
             }
@@ -3043,6 +3053,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 toggle?.classList.add('active');
                 externalToggle?.classList.add('active');
                 document.body.style.overflow = 'hidden';
+                document.addEventListener('click', this.handleOutsideSideMenuClick);
                 this.sideMenuOpen = true;
             }
 
@@ -3058,6 +3069,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 externalToggle?.classList.remove('active');
                 document.body.classList.remove('side-menu-open');
                 document.body.style.overflow = '';
+                document.removeEventListener('click', this.handleOutsideSideMenuClick);
                 this.sideMenuOpen = false;
             }
 


### PR DESCRIPTION
## Summary
- ensure the side menu overlay doesn't block pointer events
- close side menu when clicking outside it

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ca5c7749883319327694847f2a276