### PR TITLE
Ensure bottom search always opens side menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -3394,7 +3394,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const shortlist = document.getElementById('bottomShortlist');
                 const vendors = document.getElementById('bottomVendors');
 
-                if (search) search.addEventListener('click', () => this.toggleSideMenu());
+                if (search) search.addEventListener('click', () => this.openSideMenu());
                 if (shortlist) shortlist.addEventListener('click', () => this.toggleShortlistMenu());
                 if (vendors) vendors.addEventListener('click', () => {
                     this.closeSideMenu();


### PR DESCRIPTION
## Summary
- update bottom navigation search button to always open the sidebar

## Testing
- `bash -lc 'grep -n "openSideMenu" -n index.html'`


------
https://chatgpt.com/codex/tasks/task_e_685ca8dbdee08331a643e11ca9eea4d4