### PR TITLE
Fix scrolling by updating overflow rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,13 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
             min-height: 100vh;
-            overflow: hidden;
+            overflow-x: hidden;
+            overflow-y: auto;
         }
 
         html {
-            overflow: hidden;
+            overflow-x: hidden;
+            overflow-y: auto;
             height: 100%;
             min-height: 100%;
         }


### PR DESCRIPTION
## Summary
- allow page to scroll by adjusting `overflow` properties on `body` and `html`
- keep scrolling disabled when menus or modals are open

## Testing
- `grep -n "overflow" -n index.html | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_685caeff99188331b2d4ba6f60f4a6c7