### PR TITLE
Disable sidebar open on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2999,6 +2999,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (externalMenuToggle) externalMenuToggle.addEventListener('click', () => this.toggleSideMenu());
                 if (overlay) overlay.addEventListener('click', () => this.closeSideMenu());
                 if (sideMenu) sideMenu.addEventListener('click', (e) => {
+                    if (this.isMobile()) return;
                     if (!this.sideMenuOpen && e.target === sideMenu) {
                         e.stopPropagation();
                         this.openSideMenu();
@@ -3143,6 +3144,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 const shortlistMenu = document.getElementById('shortlistMenu');
                 if (shortlistMenu) shortlistMenu.addEventListener('click', (e) => {
+                    if (this.isMobile()) return;
                     if (!this.shortlistMenuOpen && e.target === shortlistMenu) {
                         e.stopPropagation();
                         this.openShortlistMenu();


### PR DESCRIPTION
## Summary
- prevent clicking hidden sidebars from opening them on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cbb0901c88331a23f734f72678447