### PR TITLE
Allow larger vendor logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,9 +516,16 @@
 
         .tool-header {
             display: flex;
-            align-items: flex-start;
+            align-items: center;
             justify-content: space-between;
             margin-bottom: 10px;
+        }
+
+        .tool-info {
+            display: flex;
+            flex-direction: column;
+            flex-grow: 1;
+            margin-left: 8px;
         }
 
         .tool-name {
@@ -537,10 +544,11 @@
             letter-spacing: 0.5px;
         }
         .tool-logo {
-            width: 32px;
-            height: 32px;
+            width: 48px;
+            height: 48px;
             object-fit: contain;
             background-color: transparent;
+            flex-shrink: 0;
         }
 
         .video-indicator {
@@ -2885,9 +2893,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 card.innerHTML = `
                     <div class="tool-card-content">
                         <div class="tool-header">
-                            <div>
+                            ${tool.logoUrl ? `<img class="tool-logo" src="${tool.logoUrl}" alt="${tool.name} logo">` : ""}
+                            <div class="tool-info">
                                 <div class="tool-name">
-                                    ${tool.logoUrl ? `<img class="tool-logo" src="${tool.logoUrl}" alt="${tool.name} logo">` : ""}
                                     ${tool.name}
                                     ${tool.videoUrl ? '<span class="video-indicator">🎥</span>' : ''}
                                 </div>


### PR DESCRIPTION
## Summary
- support larger vendor logos by restructuring card layout

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685ee07433cc83319778b313b1b83418