### PR TITLE
Add missing Datalog logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2132,7 +2132,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Advanced analytics", "Multi-entity support", "Data visualization", "Custom reporting", "Cash positioning", "Risk monitoring"],
                         "target": "Large corporations requiring sophisticated analytics and reporting",
                         "videoUrl": "https://youtu.be/qX_iOGiuNwM?si=omRZs79-y3pyZRdk",
-                        "websiteUrl": "https://www.datalog-finance.com/en/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+                        "websiteUrl": "https://www.datalog-finance.com/en/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
+                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Datalog-logo.png"
                     }, {
                         "name": "Coupa",
                         "category": "TRMS",


### PR DESCRIPTION
## Summary
- include a logo URL for Datalog so its card renders properly

## Testing
- `curl -I https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Datalog-logo.png` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f116eed2c83319d13c750eea6eda3