### PR TITLE
Fix Autocash name and adjust category icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
             gap: 12px;
             color: #281345;
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-            line-height: 1.2;
+            line-height: 1.4; /* Prevent emoji icons from being cut off */
             text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
         }
 
@@ -942,6 +942,7 @@
 
             .category-title {
                 font-size: 1.3rem;
+                line-height: 1.4;
             }
 
             .tool-name {
@@ -2172,7 +2173,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "websiteUrl": "https://www.tesorio.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
                         "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tesorio.jpg"
                     }, {
-                        "name": "Autocash.ai",
+                        "name": "Autocash",
                         "category": "CASH",
                         "desc": "AI-first cash management solution with predictive analytics, automated scenario modeling, and intelligent cash optimization recommendations.",
                         "features": ["AI predictions", "Automated scenarios", "Smart recommendations", "Risk assessment", "Cash optimization", "Intelligent alerts"],


### PR DESCRIPTION
## Summary
- remove `.ai` from the Autocash tool name
- prevent category icons from being clipped by increasing `line-height`

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f1f1d99588331a71b13103e5312ba