### PR TITLE
Adjust external toggle button offsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -1264,8 +1264,8 @@
 
         .external-menu-toggle {
             position: fixed;
-            top: 20px;
-            left: 20px;
+            top: 10px;
+            left: 5px;
             background: rgba(255,255,255,0.15);
             border: 1px solid rgba(255,255,255,0.3);
             backdrop-filter: blur(10px);
@@ -1329,8 +1329,8 @@
 
         .external-shortlist-toggle {
             position: fixed;
-            top: 20px;
-            right: 20px;
+            top: 10px;
+            right: 5px;
             background: rgba(255,255,255,0.15);
             border: 1px solid rgba(255,255,255,0.3);
             backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- tweak CSS offsets for external menu buttons so they sit closer to the page edges

## Testing
- `tidy -q index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686573e2e19c83318363727b62a270c0