### PR TITLE
Adjust vendor logo placement in cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -2974,14 +2974,14 @@ document.addEventListener('DOMContentLoaded', () => {
                             <div class="tool-info">
                                 <div class="tool-name">
                                     ${tool.name}
-                                    ${tool.videoUrl ? '<span class="video-indicator">🎥</span>' : ''}
+                                    ${tool.logoUrl ? `<img class="tool-logo-inline" src="${tool.logoUrl}" alt="${tool.name} logo">` : ''}
                                     ${tool.websiteUrl ? `<a class="tool-website-link" href="${tool.websiteUrl}" target="_blank" rel="noopener noreferrer">Visit Website</a>` : ''}
+                                    ${tool.videoUrl ? '<span class="video-indicator">🎥</span>' : ''}
                                 </div>
                                 <div class="tool-type">${tool.category === 'CASH' ? 'Cash Tools' : tool.category === 'LITE' ? 'TMS-Lite' : tool.category}</div>
                             </div>
                             <div class="tool-meta">
                                 <div class="tool-icon">${iconMap[tool.category]}</div>
-                                ${tool.logoUrl ? `<img class="tool-logo-inline" src="${tool.logoUrl}" alt="${tool.name} logo">` : ''}
                             </div>
                         </div>
                         <div class="tool-description">${tool.desc}</div>


### PR DESCRIPTION
## Summary
- move vendor logo next to tool name
- keep website link after logo
- move category icon to far right of tool cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865890b0cb88331b013a9306ac88f93