### PR TITLE
Adjust vendor card spacing and logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@
             background: #f9fafb;
             border: 1px solid #e5e7eb;
             border-radius: 12px;
-            padding: 16px;
+            padding: 12px;
             cursor: pointer;
             transition: all 0.3s ease;
             position: relative;
@@ -518,7 +518,7 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
-            margin-bottom: 10px;
+            margin-bottom: 6px;
         }
 
         .tool-meta {
@@ -531,19 +531,19 @@
             display: flex;
             flex-direction: column;
             flex-grow: 1;
-            gap: 6px; /* improve vertical spacing */
+            gap: 2px; /* tighter vertical spacing */
         }
 
         .tool-name {
             font-size: 1.2rem;
             font-weight: 700;
             color: #281345;
-            margin-bottom: 2px;
+            margin-bottom: 1px;
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             line-height: 1.2;
             display: flex;
             align-items: center;
-            gap: 16px; /* spacing between title, video icon and logo */
+            gap: 8px; /* bring logo closer to title */
             position: relative;
             z-index: 1;
             text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
## Summary
- tighten spacing at top of each vendor card
- bring category text closer to name
- move vendor logo closer to the name so the website button and icon have more room

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68658f9cda8c83318152c4990d001b29