### PR TITLE
Fix tool name spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -551,7 +551,12 @@
         }
 
         .tool-name-title {
-            margin-right: auto;
+            /* removed margin-right to keep icon flush with text */
+        }
+        .tool-name-group {
+            display: flex;
+            align-items: center;
+            gap: 4px;
         }
         .tool-logo {
             width: 100px;
@@ -3007,8 +3012,10 @@ document.addEventListener('DOMContentLoaded', () => {
                         <div class="tool-header">
                             <div class="tool-info">
                                 <div class="tool-name">
-                                    <span class="tool-name-title">${tool.name}</span>
-                                    ${tool.videoUrl ? '<span class="video-indicator">🎥</span>' : ''}
+                                    <span class="tool-name-group">
+                                        <span class="tool-name-title">${tool.name}</span>
+                                        ${tool.videoUrl ? '<span class="video-indicator">🎥</span>' : ''}
+                                    </span>
                                     ${tool.logoUrl ? `<img class="tool-logo-inline" src="${tool.logoUrl}" alt="${tool.name} logo">` : ''}
                                     ${tool.websiteUrl ? `<a class="tool-website-link" href="${tool.websiteUrl}" target="_blank" rel="noopener noreferrer">Visit<br>Website</a>` : ''}
                                 </div>


### PR DESCRIPTION
## Summary
- remove `margin-right: auto` from `.tool-name-title`
- wrap tool name and video indicator in `.tool-name-group`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686597bac1bc83319ad315dacf972298