### PR TITLE
Fix header alignment for tool cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -518,12 +518,14 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
+            flex-wrap: nowrap;
             margin-bottom: 6px;
         }
 
         .tool-meta {
             display: flex;
             align-items: center;
+            flex-wrap: nowrap;
             gap: 16px;
         }
 


### PR DESCRIPTION
## Summary
- prevent wrapping in `.tool-header` and `.tool-meta`

## Testing
- `tidy -errors -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_686597c1b7888331babc0a7a290f9f43