### PR TITLE
Adjust vendor logo alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
 
         .tool-meta {
             display: flex;
-            align-items: flex-start;
+            align-items: center; /* center items vertically */
             flex-wrap: nowrap;
             gap: 12px;
         }
@@ -572,6 +572,7 @@
             width: 90px; /* larger but still fits */
             height: 90px;
             object-fit: contain;
+            margin-left: -8px; /* nudge logo left for better alignment */
         }
 
         .modal-tool-logo {


### PR DESCRIPTION
## Summary
- tweak `.tool-meta` to vertically center vendor information
- nudge vendor logo left for better alignment with title and buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865b1e13010833192946e97cd298390