### PR TITLE
style: align vendor logos with header

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,11 +569,18 @@
         }
 
         .tool-logo-inline {
-            width: 40px; /* smaller logo to align with header */
-            height: 40px;
+            width: 90px; /* keep full size on desktop */
+            height: 90px;
             object-fit: contain;
-            margin-left: -4px; /* shift slightly left */
+            margin-left: -8px; /* nudge left */
             margin-top: -4px; /* lift logo to line up with title */
+        }
+
+        @media (max-width: 768px) {
+            .tool-logo-inline {
+                width: 60px; /* slightly smaller on mobile */
+                height: 60px;
+            }
         }
 
         .modal-tool-logo {

--- a/index.html
+++ b/index.html
@@ -569,10 +569,11 @@
         }
 
         .tool-logo-inline {
-            width: 90px; /* larger but still fits */
-            height: 90px;
+            width: 40px; /* smaller logo to align with header */
+            height: 40px;
             object-fit: contain;
-            margin-left: -8px; /* nudge logo left for better alignment */
+            margin-left: -4px; /* shift slightly left */
+            margin-top: -4px; /* lift logo to line up with title */
         }
 
         .modal-tool-logo {


### PR DESCRIPTION
## Summary
- adjust `.tool-logo-inline` dimensions and margins so vendor logos align better with the title and category icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865fb0690e883319e8ad604d798af4d