### PR TITLE
Move website link next to modal close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -752,11 +752,11 @@
             display: flex;
             align-items: center;
             gap: 12px;
-            flex-grow: 1;
+            margin-left: auto;
         }
 
         .modal-header-actions .modal-close {
-            margin-left: auto;
+            margin-left: 0;
         }
         
         /* Modal Body: Scrollable */


### PR DESCRIPTION
## Summary
- update vendor modal header CSS so the website link aligns near the close button

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6866017bc0508331953c59338156f228