### PR TITLE
Display vendor video above tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -2866,9 +2866,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     `;
                 }
 
-                // Always place the video or demo section at the end of the modal
-                // body so informational text appears below the other details
-                modalBody.appendChild(videoSection);
+                // Insert the video/demo section before the tag list so it
+                // appears directly beneath the overview
+                const tagSection = modalTags?.closest('.feature-section');
+                if (tagSection) {
+                    modalBody.insertBefore(videoSection, tagSection);
+                } else {
+                    modalBody.appendChild(videoSection);
+                }
 
                 // 4. Show the modal
                 this.openModal(modal);


### PR DESCRIPTION
## Summary
- insert vendor video section above tag list in tool modal so it displays right below overview

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68660299709883319215cc9e7ea105f6