### PR TITLE
Add ATOM tool website link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2177,6 +2177,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "desc": "Enterprise treasury platform focused on derivatives trading, risk management, and automated workflow processing for sophisticated financial operations.",
                         "features": ["Derivatives trading", "Automated workflows", "Risk management", "Trade processing", "Compliance monitoring", "Real-time analytics"],
                         "target": "Large corporations and financial institutions with active trading operations",
+                        "websiteUrl": "https://www.fisci.com/atom-treasury-risk/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
                         "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/ATOM-TM.png"
                     }, {
                         "name": "Integrity",


### PR DESCRIPTION
## Summary
- add missing website URL for the ATOM tool

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686603a29c9883319ee5d1021b9b610f