### PR TITLE
Fix logo size in vendor cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,10 +565,10 @@
         }
 
         .tool-logo-inline {
-            width: 90px; /* keep full size on desktop */
-            height: 90px;
+            width: 40px;
+            height: 40px;
             object-fit: contain;
-            margin-top: -4px; /* lift logo to line up with title */
+            margin-top: 0;
         }
 
         .tool-logo-inline.no-video {
@@ -577,8 +577,8 @@
 
         @media (max-width: 768px) {
             .tool-logo-inline {
-                width: 60px; /* slightly smaller on mobile */
-                height: 60px;
+                width: 30px;
+                height: 30px;
             }
         }
 


### PR DESCRIPTION
## Summary
- decrease `.tool-logo-inline` size so header height stays compact
- set smaller logo size at the mobile breakpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686606316c54833199d6c6f60d35ecc9