### PR TITLE
Fix modal icon order

### DIFF
--- a/index.html
+++ b/index.html
@@ -1982,8 +1982,8 @@
                     <img id="modalToolLogo" class="modal-tool-logo" alt="">
                     <div class="modal-header-actions">
                         <a id="modalWebsiteLink" href="#" target="_blank" rel="noopener noreferrer" class="website-link--modal" style="display: none;">Website</a>
-                        <div id="modalCategoryIcon" class="tool-icon"></div>
                         <button class="modal-close" id="modalClose">×</button>
+                        <div id="modalCategoryIcon" class="tool-icon"></div>
                     </div>
                 </div>
                 <div class="modal-body">


### PR DESCRIPTION
## Summary
- adjust `index.html` modal header actions so the category icon sits after the close button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68660bf6f8148331948eddd5e65c8995