### PR TITLE
Move website link next to vendor icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,8 +642,15 @@
             -webkit-backdrop-filter: blur(4px);
         }
 
-        .tool-card .tool-name .tool-icon {
+        .tool-actions {
             margin-left: auto;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .tool-card .tool-name .tool-icon {
+            margin-left: 0;
         }
 
         .tool-description {
@@ -3169,8 +3176,10 @@ document.addEventListener('DOMContentLoaded', () => {
                                     <span class="tool-name-title">${tool.name}</span>
                                     ${tool.videoUrl ? '<span class="video-indicator">🎥</span>' : ''}
                                     ${tool.logoUrl ? `<img class="tool-logo-inline${tool.videoUrl ? '' : ' no-video'}" src="${tool.logoUrl}" alt="${tool.name} logo">` : ''}
-                                    ${tool.websiteUrl ? `<a class="tool-website-link" href="${tool.websiteUrl}" target="_blank" rel="noopener noreferrer">Website</a>` : ''}
-                                    <div class="tool-icon">${iconMap[tool.category]}</div>
+                                    <div class="tool-actions">
+                                        ${tool.websiteUrl ? `<a class="tool-website-link" href="${tool.websiteUrl}" target="_blank" rel="noopener noreferrer">Website</a>` : ''}
+                                        <div class="tool-icon">${iconMap[tool.category]}</div>
+                                    </div>
                                 </div>
                                 <div class="tool-type">${tool.category === 'CASH' ? 'Cash Tools' : tool.category === 'LITE' ? 'TMS-Lite' : tool.category}</div>
                             </div>


### PR DESCRIPTION
## Summary
- group website button and category icon in a new `tool-actions` container
- style `tool-actions` so the link precedes the icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68660fca892c83318f4113a8ae844493